### PR TITLE
update in line with lodash + pulling out the regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Other improvements:
 
-- Update casing functions internal implementation of splitting unicod words according to the lodash reference and move regexes up to the top level (#11)
+- Update casing functions internal implementation of splitting unicode words according to the lodash reference and move regexes up to the top level ([#11](https://github.com/purescript-contrib/purescript-strings-extra/pull/11))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Other improvements:
+
+- Update casing functions internal implementation of splitting unicod words according to the lodash reference and move regexes up to the top level (#11)

--- a/src/Data/String/Extra.purs
+++ b/src/Data/String/Extra.purs
@@ -20,7 +20,7 @@ import Data.String.Regex (Regex)
 import Data.String.Regex as Regex
 import Data.String.Regex.Flags as Flags
 import Partial.Unsafe (unsafePartial)
-import Prelude ((>>>), (<>), map)
+import Prelude ((>>>), (<>), ($), map)
 
 -- | Converts a `String` to camel case
 -- |
@@ -34,7 +34,7 @@ camelCase =
 
 -- | Converts a `String` to kebab case
 -- |
--- | ```pures
+-- | ```purs
 -- | kebabCase "Hello world" == "hello-world"
 -- | ```
 kebabCase :: String -> String
@@ -103,14 +103,21 @@ regexGlobal :: String -> Regex
 regexGlobal regexStr =
   unsafePartial fromRight (Regex.regex regexStr Flags.global)
 
+regexHasASCIIWords :: Regex
+regexHasASCIIWords =
+  regexGlobal "[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+"
+
 asciiWords :: String -> Array String
 asciiWords =
-  Regex.match (regexGlobal "[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+")
-    >>> foldMap NonEmptyArray.catMaybes
+  Regex.match regexHasASCIIWords >>> foldMap NonEmptyArray.catMaybes
+
+regexHasUnicodeWords :: Regex
+regexHasUnicodeWords =
+  regexGlobal "[a-z][A-Z]|[A-Z]{2,}[a-z]|[0-9][a-zA-Z]|[a-zA-Z][0-9]|[^a-zA-Z0-9]"
 
 hasUnicodeWords :: String -> Boolean
 hasUnicodeWords =
-  Regex.test (regexGlobal "[a-z][A-Z]|[A-Z]{2,}[a-z]|[0-9][a-zA-Z]|[a-zA-Z][0-9]|[^a-zA-Z0-9]")
+  Regex.test regexHasUnicodeWords
 
 toUnicodeLower :: String -> String
 toUnicodeLower =
@@ -120,66 +127,68 @@ toUnicodeUpper :: String -> String
 toUnicodeUpper =
   SCU.toCharArray >>> map Unicode.toUpper >>> SCU.fromCharArray
 
-unicodeWords :: String -> Array String
-unicodeWords =
-  Regex.match (regexGlobal regexStr) >>> foldMap NonEmptyArray.catMaybes
-  where
-    -- https://github.com/lodash/lodash/blob/master/.internal/unicodeWords.js
-    -- Used to compose unicode character classes.
-    rsAstralRange = "\\ud800-\\udfff"
-    rsComboMarksRange = "\\u0300-\\u036f"
-    reComboHalfMarksRange = "\\ufe20-\\ufe2f"
-    rsComboSymbolsRange = "\\u20d0-\\u20ff"
-    rsComboRange = rsComboMarksRange <> reComboHalfMarksRange <> rsComboSymbolsRange
-    rsDingbatRange = "\\u2700-\\u27bf"
-    rsLowerRange = "a-z\\xdf-\\xf6\\xf8-\\xff"
-    rsMathOpRange = "\\xac\\xb1\\xd7\\xf7"
-    rsNonCharRange = "\\x00-\\x2f\\x3a-\\x40\\x5b-\\x60\\x7b-\\xbf"
-    rsPunctuationRange = "\\u2000-\\u206f"
-    rsSpaceRange = " \\t\\x0b\\f\\xa0\\ufeff\\n\\r\\u2028\\u2029\\u1680\\u180e\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a\\u202f\\u205f\\u3000"
-    rsUpperRange = "A-Z\\xc0-\\xd6\\xd8-\\xde"
-    rsVarRange = "\\ufe0e\\ufe0f"
-    rsBreakRange = rsMathOpRange <> rsNonCharRange <> rsPunctuationRange <> rsSpaceRange
-
-    -- Used to compose unicode capture groups.
-    rsApos = "['\\u2019]"
-    rsBreak = "[" <> rsBreakRange <> "]"
-    rsCombo = "[" <> rsComboRange <> "]"
-    rsDigits = "\\d+"
-    rsDingbat = "[" <> rsDingbatRange <> "]"
-    rsLower = "[" <> rsLowerRange <> "]"
-    rsMisc = "[^" <> rsAstralRange <> rsBreakRange <> rsDigits <> rsDingbatRange <> rsLowerRange <> rsUpperRange <> "]"
-    rsFitz = "\\ud83c[\\udffb-\\udfff]"
-    rsModifier = "(?:" <> rsCombo <> "|" <> "rsFitz)"
-    rsNonAstral = "[^" <> rsAstralRange <> "]"
-    rsRegional = "(?:\\ud83c[\\udde6-\\uddff]){2}"
-    rsSurrPair = "[\\ud800-\\udbff][\\udc00-\\udfff]"
-    rsUpper = "[" <> rsUpperRange <> "]"
-    rsZWJ = "\\u200d"
-
-    -- Used to compose unicode regexes.
-    rsMiscLower = "(?:" <> rsLower <> "|" <> rsMisc <> ")"
-    rsMiscUpper = "(?:" <> rsUpper <> "|" <> rsMisc <> ")"
-    rsOptContrLower = "(?:" <> rsApos <> "(?:d|ll|m|re|s|t|ve))?"
-    rsOptContrUpper = "(?:" <> rsApos <> "(?:D|LL|M|RE|S|T|VE))?"
-    reOptMod = rsModifier <> "?"
-    rsOptVar = "[" <> rsVarRange <> "]?"
-    rsOptJoin = "(?:" <> rsZWJ <> "(?:" <> rsNonAstral <> "|" <> rsRegional <> "|" <> rsSurrPair <> ")" <> rsOptVar <> reOptMod <> ")*"
-    rsOrdLower = "\\d*(?:(?:1st|2nd|3rd|(?![123])\\dth)\\b)"
-    rsOrdUpper = "\\d*(?:(?:1ST|2ND|3RD|(?![123])\\dTH)\\b)"
-    rsSeq = rsOptVar <> reOptMod <> rsOptJoin
-    rsEmoji = "(?:" <> rsDingbat <> "|" <> rsRegional <> "|" <> rsSurrPair <> ")" <> rsSeq
-
-    -- Put it all together
-    regexStr :: String
-    regexStr =
-      String.joinWith "|"
+regexUnicodeWords :: Regex
+regexUnicodeWords =
+  regexGlobal
+    $ String.joinWith "|"
         [ rsUpper <> "?" <> rsLower <> "+" <> rsOptContrLower <> "(?=" <> rsBreak <> "|" <> rsUpper <> "|$)"
         , rsMiscUpper <> "+" <> rsOptContrUpper <> "(?=" <> rsBreak <> "|" <> rsUpper <> rsMiscLower <> "|$)"
         , rsUpper <> "?" <> rsMiscLower <> "+" <> rsOptContrLower
         , rsUpper <> "+" <> rsOptContrUpper
         , rsOrdUpper
         , rsOrdLower
-        , rsDigits
+        , rsDigit <> "+"
         , rsEmoji
         ]
+  where
+  -- https://github.com/lodash/lodash/blob/master/.internal/unicodeWords.js
+  -- Used to compose unicode character classes.
+  rsAstralRange = "\\ud800-\\udfff"
+  rsComboMarksRange = "\\u0300-\\u036f"
+  reComboHalfMarksRange = "\\ufe20-\\ufe2f"
+  rsComboSymbolsRange = "\\u20d0-\\u20ff"
+  rsComboMarksExtendedRange = "\\u1ab0-\\u1aff"
+  rsComboMarksSupplementRange = "\\u1dc0-\\u1dff"
+  rsComboRange = rsComboMarksRange <> reComboHalfMarksRange <> rsComboSymbolsRange <> rsComboMarksExtendedRange <> rsComboMarksSupplementRange
+  rsDingbatRange = "\\u2700-\\u27bf"
+  rsLowerRange = "a-z\\xdf-\\xf6\\xf8-\\xff"
+  rsMathOpRange = "\\xac\\xb1\\xd7\\xf7"
+  rsNonCharRange = "\\x00-\\x2f\\x3a-\\x40\\x5b-\\x60\\x7b-\\xbf"
+  rsPunctuationRange = "\\u2000-\\u206f"
+  rsSpaceRange = " \\t\\x0b\\f\\xa0\\ufeff\\n\\r\\u2028\\u2029\\u1680\\u180e\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a\\u202f\\u205f\\u3000"
+  rsUpperRange = "A-Z\\xc0-\\xd6\\xd8-\\xde"
+  rsVarRange = "\\ufe0e\\ufe0f"
+  rsBreakRange = rsMathOpRange <> rsNonCharRange <> rsPunctuationRange <> rsSpaceRange
+
+  -- Used to compose unicode capture groups.
+  rsApos = "['\\u2019]"
+  rsBreak = "[" <> rsBreakRange <> "]"
+  rsCombo = "[" <> rsComboRange <> "]"
+  rsDigit = "\\d"
+  rsDingbat = "[" <> rsDingbatRange <> "]"
+  rsLower = "[" <> rsLowerRange <> "]"
+  rsMisc = "[^" <> rsAstralRange <> rsBreakRange <> rsDigit <> rsDingbatRange <> rsLowerRange <> rsUpperRange <> "]"
+  rsFitz = "\\ud83c[\\udffb-\\udfff]"
+  rsModifier = "(?:" <> rsCombo <> "|" <> "rsFitz)"
+  rsNonAstral = "[^" <> rsAstralRange <> "]"
+  rsRegional = "(?:\\ud83c[\\udde6-\\uddff]){2}"
+  rsSurrPair = "[\\ud800-\\udbff][\\udc00-\\udfff]"
+  rsUpper = "[" <> rsUpperRange <> "]"
+  rsZWJ = "\\u200d"
+
+  -- Used to compose unicode regexes.
+  rsMiscLower = "(?:" <> rsLower <> "|" <> rsMisc <> ")"
+  rsMiscUpper = "(?:" <> rsUpper <> "|" <> rsMisc <> ")"
+  rsOptContrLower = "(?:" <> rsApos <> "(?:d|ll|m|re|s|t|ve))?"
+  rsOptContrUpper = "(?:" <> rsApos <> "(?:D|LL|M|RE|S|T|VE))?"
+  reOptMod = rsModifier <> "?"
+  rsOptVar = "[" <> rsVarRange <> "]?"
+  rsOptJoin = "(?:" <> rsZWJ <> "(?:" <> rsNonAstral <> "|" <> rsRegional <> "|" <> rsSurrPair <> ")" <> rsOptVar <> reOptMod <> ")*"
+  rsOrdLower = "\\d*(?:1st|2nd|3rd|(?![123])\\dth)(?=\\b|[A-Z_])"
+  rsOrdUpper = "\\d*(?:1ST|2ND|3RD|(?![123])\\dTH)(?=\\b|[a-z_])"
+  rsSeq = rsOptVar <> reOptMod <> rsOptJoin
+  rsEmoji = "(?:" <> rsDingbat <> "|" <> rsRegional <> "|" <> rsSurrPair <> ")" <> rsSeq
+
+unicodeWords :: String -> Array String
+unicodeWords =
+  Regex.match regexUnicodeWords >>> foldMap NonEmptyArray.catMaybes

--- a/src/Data/String/Extra.purs
+++ b/src/Data/String/Extra.purs
@@ -7,7 +7,6 @@ module Data.String.Extra
   , words
   , levenshtein
   , sorensenDiceCoefficient
-  , upperCaseFirst
   ) where
 
 import Data.Array as Array

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -13,6 +13,7 @@ main = do
     assert $ String.camelCase "" == ""
     assert $ String.camelCase " " == ""
     assert $ String.camelCase "\n" == ""
+    assert $ String.camelCase "ASCII" == "ascii"
     assert $ String.camelCase "🙃" == "🙃"
     assert $ String.camelCase "Thor" == "thor"
     assert $ String.camelCase "Thor, Mímir, Ēostre, & Jörð" == "thorMímirĒostreJörð"
@@ -23,6 +24,7 @@ main = do
     assert $ String.kebabCase "" == ""
     assert $ String.kebabCase " " == ""
     assert $ String.kebabCase "\n" == ""
+    assert $ String.kebabCase "ASCII" == "ascii"
     assert $ String.kebabCase "🙃" == "🙃"
     assert $ String.kebabCase "Thor" == "thor"
     assert $ String.kebabCase "Thor, Mímir, Ēostre, & Jörð" == "thor-mímir-ēostre-jörð"
@@ -33,6 +35,7 @@ main = do
     assert $ String.pascalCase "" == ""
     assert $ String.pascalCase " " == ""
     assert $ String.pascalCase "\n" == ""
+    assert $ String.pascalCase "ASCII" == "Ascii"
     assert $ String.pascalCase "🙃" == "🙃"
     assert $ String.pascalCase "Thor" == "Thor"
     assert $ String.pascalCase "Thor, Mímir, Ēostre, & Jörð" == "ThorMímirĒostreJörð"
@@ -43,6 +46,7 @@ main = do
     assert $ String.snakeCase "" == ""
     assert $ String.snakeCase " " == ""
     assert $ String.snakeCase "\n" == ""
+    assert $ String.snakeCase "ASCII" == "ascii"
     assert $ String.snakeCase "🙃" == "🙃"
     assert $ String.snakeCase "Thor" == "thor"
     assert $ String.snakeCase "Thor, Mímir, Ēostre, & Jörð" == "thor_mímir_ēostre_jörð"
@@ -53,6 +57,7 @@ main = do
     assert $ String.upperCaseFirst "" == ""
     assert $ String.upperCaseFirst " " == " "
     assert $ String.upperCaseFirst "\n" == "\n"
+    assert $ String.upperCaseFirst "ASCII" == "Ascii"
     assert $ String.upperCaseFirst "🙃" == "🙃"
     assert $ String.upperCaseFirst "Thor" == "Thor"
     assert $ String.upperCaseFirst "Thor, Mímir, Ēostre, & Jörð" == "Thor, mímir, ēostre, & jörð"
@@ -63,6 +68,7 @@ main = do
     assert $ String.words "" == []
     assert $ String.words " " == []
     assert $ String.words "\n" == []
+    assert $ String.words "ASCII" == [ "ASCII" ]
     assert $ String.words "🙃" == [ "🙃" ]
     assert $ String.words "Thor" == [ "Thor" ]
     assert $ String.words "Thor, Mímir, Ēostre, & Jörð" == [ "Thor", "Mímir", "Ēostre", "Jörð" ]


### PR DESCRIPTION
**Description of the change**
fixes #10 

There were some fixes to lodash's implementation that this library borrows its casings from. I moved the Regexs up a level which should be more efficient than re-instantiating (??). I added a test for something I found unexpected in that `ASCII` in PascalCase is `Ascii` (not all caps). Fixed `pures` -> `purs`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
